### PR TITLE
feat: enforce bungalow spacing and spawn conditions

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -194,6 +194,7 @@ public final class Thaw extends JavaPlugin {
 
                 for (Location loc : toPlace) {
                     schematicManager.placeStructure("pacifist", loc);
+                    gen.registerBungalow(loc);
                 }
             }, 200L, 200L);
         });


### PR DESCRIPTION
## Summary
- Track bungalow locations and skip new spawns within 100 blocks
- Validate 15x15 snow platforms at Y155-156 without sand or water before queuing a bungalow
- Record placed bungalow locations during world load

## Testing
- `mvn -DskipTests package` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c38477e8988332894904e8d27fdd1c