### PR TITLE
feat: add hypothermia and frostbite effects

### DIFF
--- a/src/main/java/goat/thaw/system/effects/EffectId.java
+++ b/src/main/java/goat/thaw/system/effects/EffectId.java
@@ -1,6 +1,8 @@
 package goat.thaw.system.effects;
 
 public enum EffectId {
-    HYPOXIA
+    HYPOXIA,
+    HYPOTHERMIA,
+    FROSTBITE
 }
 


### PR DESCRIPTION
## Summary
- apply hypothermia I/II and frostbite based on player temperature
- map hypothermia and frostbite to appropriate potion effects
- expose new effect ids for hypothermia and frostbite

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c48e563d8c8332b7b40f08da54a7d5