### PR TITLE
feat: add toggleeffects dev command

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -31,6 +31,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
 import goat.thaw.system.dev.BungalowLootManager;
+import goat.thaw.system.dev.ToggleEffectsCommand;
 
 public final class Thaw extends JavaPlugin {
 
@@ -175,6 +176,9 @@ public final class Thaw extends JavaPlugin {
         }
         if (getCommand("dicelog") != null) {
             getCommand("dicelog").setExecutor(new DiceLogCommand(diceLogger));
+        }
+        if (getCommand("toggleeffects") != null) {
+            getCommand("toggleeffects").setExecutor(new ToggleEffectsCommand(effectManager));
         }
 
         Bukkit.getScheduler().runTask(this, () -> {

--- a/src/main/java/goat/thaw/system/dev/ToggleEffectsCommand.java
+++ b/src/main/java/goat/thaw/system/dev/ToggleEffectsCommand.java
@@ -1,0 +1,27 @@
+package goat.thaw.system.dev;
+
+import goat.thaw.system.effects.EffectManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class ToggleEffectsCommand implements CommandExecutor {
+    private final EffectManager effects;
+
+    public ToggleEffectsCommand(EffectManager effects) {
+        this.effects = effects;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        Player p = (Player) sender;
+        boolean enabled = effects.toggle(p.getUniqueId());
+        p.sendMessage(enabled ? "Effects enabled." : "Effects disabled.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -61,6 +61,11 @@ commands:
     usage: /dicelog
     permission: thaw.dev
     permission-message: You must be op to use this.
+  toggleeffects:
+    description: Toggle custom effects on or off
+    usage: /toggleeffects
+    permission: thaw.dev
+    permission-message: You must be op to use this.
   sled:
     description: Dev SLED airboat
     usage: /sled <dogCount 1-2>


### PR DESCRIPTION
## Summary
- add `/toggleeffects` to let developers disable or enable custom effects on themselves
- track effect disabling in `EffectManager` to skip applying potions when toggled off
- register the command in `plugin.yml` and main plugin

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*
- `mvn -o -q -DskipTests package` *(fails: artifact not previously downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68c49b2859a88332b193388d40853270