### PR TITLE
fix: disallow nether space creation

### DIFF
--- a/src/main/java/goat/thaw/system/dev/FloodFillAlgorithmCommand.java
+++ b/src/main/java/goat/thaw/system/dev/FloodFillAlgorithmCommand.java
@@ -56,6 +56,11 @@ public class FloodFillAlgorithmCommand implements CommandExecutor {
             return true;
         }
         Player player = (Player) sender;
+        World.Environment env = player.getWorld().getEnvironment();
+        if (env != World.Environment.NORMAL && env != World.Environment.THE_END) {
+            player.sendMessage("Space mapping is only supported in the Overworld and the End.");
+            return true;
+        }
 
         Block start = player.getLocation().getBlock().getRelative(0, 1, 0);
         FillSession session = new FillSession(player);

--- a/src/main/java/goat/thaw/system/space/SpaceManager.java
+++ b/src/main/java/goat/thaw/system/space/SpaceManager.java
@@ -122,6 +122,11 @@ public class SpaceManager {
         }
 
         World world = player.getWorld();
+        World.Environment env = world.getEnvironment();
+        if (env != World.Environment.NORMAL && env != World.Environment.THE_END) {
+            player.sendMessage("Spaces cannot be created in this dimension.");
+            return Optional.empty();
+        }
         final Deque<Block> stack = new ArrayDeque<>();
         final Set<String> visited = new HashSet<>();
         final Set<BlockPos> collected = new HashSet<>();
@@ -202,6 +207,11 @@ public class SpaceManager {
         }
 
         World world = seed.getWorld();
+        World.Environment env = world.getEnvironment();
+        if (env != World.Environment.NORMAL && env != World.Environment.THE_END) {
+            player.sendMessage("Spaces cannot be created in this dimension.");
+            return Optional.empty();
+        }
         final Deque<Block> stack = new ArrayDeque<>();
         final Set<String> visited = new HashSet<>();
         final Set<BlockPos> collected = new HashSet<>();


### PR DESCRIPTION
## Summary
- prevent space creation outside the Overworld and the End
- block dev flood-fill command in unsupported dimensions

## Testing
- `mvn -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b01d25c88332b8b33140245d1cd8