### PR TITLE
feat: implement nether heat bias and fire tick management

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -24,6 +24,7 @@ import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.plugin.java.JavaPlugin;
 import goat.thaw.subsystems.temperature.DiceManager;
+import goat.thaw.subsystems.temperature.FireTickManager;
 import goat.thaw.system.logging.DiceLogger;
 import goat.thaw.system.effects.EffectManager;
 import goat.thaw.subsystems.oxygen.OxygenManager;
@@ -53,6 +54,7 @@ public final class Thaw extends JavaPlugin {
     private SledManager sledManager;
     private EffectManager effectManager;
     private OxygenManager oxygenManager;
+    private FireTickManager fireTickManager;
     private SchemManager schematicManager;
     private BungalowLootManager lootManager;
     private static final List<String> BUNGALOW_SCHEMATICS = Arrays.asList(
@@ -159,6 +161,10 @@ public final class Thaw extends JavaPlugin {
         effectManager = new EffectManager(this, statsManager);
         effectManager.start();
 
+        // Fire ticks adjust based on temperature
+        fireTickManager = new FireTickManager(this, statsManager);
+        fireTickManager.start();
+
         // Sidebar: live environment HUD with Temperature
         sidebarManager = new SidebarManager(this, statsManager);
         sidebarManager.start();
@@ -247,6 +253,7 @@ public final class Thaw extends JavaPlugin {
         if (diceManager != null) diceManager.stop();
         if (sledManager != null) sledManager.stopAll();
         if (effectManager != null) effectManager.stop();
+        if (fireTickManager != null) fireTickManager.stop();
         if (oxygenManager != null) oxygenManager.stop();
     }
 

--- a/src/main/java/goat/thaw/subsystems/temperature/DiceManager.java
+++ b/src/main/java/goat/thaw/subsystems/temperature/DiceManager.java
@@ -65,7 +65,13 @@ public class DiceManager implements Listener {
         int y = p.getLocation().getBlockY() + 1; // one above feet
         int z = p.getLocation().getBlockZ();
 
-        double externalBias = computeExternalTemperatureDFS(w, x, y, z);
+        double externalBias;
+        if (w.getEnvironment() == World.Environment.NETHER) {
+            // Nether baseline is extremely hot
+            externalBias = 200.0;
+        } else {
+            externalBias = computeExternalTemperatureDFS(w, x, y, z);
+        }
 
         // Update ExternalTemperature stat
         StatInstance ext = stats.get(p.getUniqueId(), "ExternalTemperature");

--- a/src/main/java/goat/thaw/subsystems/temperature/FireTickManager.java
+++ b/src/main/java/goat/thaw/subsystems/temperature/FireTickManager.java
@@ -1,0 +1,59 @@
+package goat.thaw.subsystems.temperature;
+
+import goat.thaw.system.stats.StatInstance;
+import goat.thaw.system.stats.StatsManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Adjusts existing fire ticks on players based on their body temperature.
+ * Does not ignite players; only modifies ongoing fire duration.
+ */
+public class FireTickManager {
+    private final JavaPlugin plugin;
+    private final StatsManager stats;
+    private BukkitTask task;
+
+    public FireTickManager(JavaPlugin plugin, StatsManager stats) {
+        this.plugin = plugin;
+        this.stats = stats;
+    }
+
+    public void start() {
+        task = Bukkit.getScheduler().runTaskTimer(plugin, this::tick, 20L, 20L); // every second
+    }
+
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+    }
+
+    private void tick() {
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            int fire = p.getFireTicks();
+            if (fire <= 0) continue;
+
+            StatInstance temp = stats.get(p.getUniqueId(), "Temperature");
+            double t = temp != null ? temp.get() : 72.0;
+
+            if (t < 50.0) {
+                // Too cold to maintain fire
+                p.setFireTicks(0);
+            } else if (t < 65.0) {
+                // Halve remaining duration
+                p.setFireTicks(Math.max(0, fire - 20));
+            } else if (t >= 190.0) {
+                // Overheated: maintain high ticks for permanent burn
+                p.setFireTicks(Math.max(fire, 160));
+            } else if (t > 100.0) {
+                // Hotter: extend burn time by ~50%
+                p.setFireTicks(fire + 7);
+            }
+        }
+    }
+}
+

--- a/src/main/java/goat/thaw/system/effects/EffectId.java
+++ b/src/main/java/goat/thaw/system/effects/EffectId.java
@@ -3,6 +3,7 @@ package goat.thaw.system.effects;
 public enum EffectId {
     HYPOXIA,
     HYPOTHERMIA,
-    FROSTBITE
+    FROSTBITE,
+    OVERHEATED
 }
 

--- a/src/main/java/goat/thaw/system/effects/EffectManager.java
+++ b/src/main/java/goat/thaw/system/effects/EffectManager.java
@@ -138,6 +138,8 @@ public class EffectManager implements Listener {
             evaluateHypoxia(p);
             // Circumstantial: Hypothermia/Frostbite based on Temperature
             evaluateHypothermia(p);
+            // Circumstantial: Overheated when extremely hot
+            evaluateOverheated(p);
 
             // Timed effects countdown
             Map<EffectId, ActiveEffect> map = active.get(id);
@@ -231,6 +233,17 @@ public class EffectManager implements Listener {
         }
     }
 
+    private void evaluateOverheated(Player p) {
+        StatInstance temp = statsManager.get(p.getUniqueId(), "Temperature");
+        if (temp == null) return;
+        double t = temp.get();
+        if (t >= 190.0) {
+            setCircumstantial(p, EffectId.OVERHEATED, 1);
+        } else {
+            setCircumstantial(p, EffectId.OVERHEATED, 0);
+        }
+    }
+
     private void setCircumstantial(Player p, EffectId id, int level) {
         Map<EffectId, ActiveEffect> map = active.computeIfAbsent(p.getUniqueId(), k -> new EnumMap<>(EffectId.class));
         ActiveEffect current = map.get(id);
@@ -256,6 +269,7 @@ public class EffectManager implements Listener {
             case HYPOXIA -> applyHypoxiaPotions(p, level);
             case HYPOTHERMIA -> applyHypothermiaPotions(p, level);
             case FROSTBITE -> applyFrostbitePotions(p, level);
+            case OVERHEATED -> { /* no potions */ }
         }
     }
 
@@ -264,6 +278,7 @@ public class EffectManager implements Listener {
             case HYPOXIA -> clearHypoxiaPotions(p);
             case HYPOTHERMIA -> clearHypothermiaPotions(p);
             case FROSTBITE -> clearFrostbitePotions(p);
+            case OVERHEATED -> { /* nothing to clear */ }
         }
     }
 
@@ -379,6 +394,7 @@ public class EffectManager implements Listener {
             case HYPOXIA -> "Hypoxia";
             case HYPOTHERMIA -> "Hypothermia";
             case FROSTBITE -> "Frostbite";
+            case OVERHEATED -> "Overheated";
         };
     }
 


### PR DESCRIPTION
## Summary
- Set Nether external temperature baseline to 200°F
- Add Overheated effect and fire tick manager that adjusts ongoing burn time by body temperature
- Wire fire tick manager into plugin lifecycle

## Testing
- `mvn -DskipTests package` *(fails: Could not transfer artifact ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4afe9b79c8332bd7d85b521c607e8