### PR TITLE
feat: add loot tables for time capsules

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -31,6 +31,7 @@ import goat.thaw.subsystems.oxygen.OxygenManager;
 import org.bukkit.scheduler.BukkitRunnable;
 import goat.thaw.system.capsule.CapsuleRegistry;
 import goat.thaw.system.capsule.CapsuleGolemListener;
+import goat.thaw.system.capsule.CapsuleLootManager;
 import goat.thaw.subsystems.eyespy.EyeSpyManager;
 
 import java.util.*;
@@ -61,6 +62,7 @@ public final class Thaw extends JavaPlugin {
     private EyeSpyManager eyeSpyManager;
     private SchemManager schematicManager;
     private BungalowLootManager lootManager;
+    private CapsuleLootManager capsuleLootManager;
     private static final List<String> BUNGALOW_SCHEMATICS = Arrays.asList(
             "fire",
             "scholar",
@@ -92,6 +94,7 @@ public final class Thaw extends JavaPlugin {
         // Schematic system
         schematicManager = new SchemManager(this);
         lootManager = new BungalowLootManager();
+        capsuleLootManager = new CapsuleLootManager();
         
         if (getCommand("testschem") != null) {
             getCommand("testschem").setExecutor(new TestSchemCommand(schematicManager));
@@ -254,6 +257,8 @@ public final class Thaw extends JavaPlugin {
                     String schem = CapsuleRegistry.random();
                     if (schem != null) {
                         schematicManager.placeStructure(schem, loc);
+                        String type = schem.toUpperCase();
+                        Bukkit.getScheduler().runTaskLater(this, () -> capsuleLootManager.populateLoot(loc, type), 20L);
                     }
                 }
             }, 200L, 200L);

--- a/src/main/java/goat/thaw/system/capsule/CapsuleLootManager.java
+++ b/src/main/java/goat/thaw/system/capsule/CapsuleLootManager.java
@@ -1,0 +1,85 @@
+package goat.thaw.system.capsule;
+
+import goat.thaw.Thaw;
+import goat.thaw.system.dev.SimpleLootPopulator;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.inventory.Inventory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles loot population for time capsules.
+ * Each capsule type has its own loot table backed by {@link SimpleLootPopulator}.
+ */
+public class CapsuleLootManager {
+
+    private final Map<String, SimpleLootPopulator> lootPopulators = new HashMap<>();
+
+    public CapsuleLootManager() {
+        initializeLootPopulators();
+    }
+
+    private void initializeLootPopulators() {
+        // LILAC capsule
+        SimpleLootPopulator lilac = new SimpleLootPopulator();
+        lilac.add(Material.AMETHYST_SHARD, 2, 8, 5);
+        lilac.add(Material.PURPLE_DYE, 1, 4, 3);
+        lilac.add(Material.CHORUS_FRUIT, 1, 2, 1);
+        lootPopulators.put("LILAC", lilac);
+    }
+
+    /**
+     * Searches for nearby chests around the capsule location and populates them
+     * using the capsule's loot table.
+     *
+     * @param structureLocation location where the capsule was placed
+     * @param type               capsule type (schematic name)
+     */
+    public void populateLoot(Location structureLocation, String type) {
+        if (structureLocation.getWorld() == null) return;
+
+        int chestsFound = 0;
+
+        // Search in a 10-block radius around the structure location
+        for (int x = -10; x <= 10; x++) {
+            for (int y = -10; y <= 10; y++) {
+                for (int z = -10; z <= 10; z++) {
+                    Block block = structureLocation.clone().add(x, y, z).getBlock();
+
+                    if ((block.getType() == Material.CHEST || block.getType() == Material.TRAPPED_CHEST) && chestsFound < 1) {
+                        Location chestLoc = block.getLocation();
+
+                        Bukkit.getScheduler().runTaskLater(Thaw.getInstance(), () -> {
+                            Block liveBlock = chestLoc.getBlock();
+                            if (!(liveBlock.getState() instanceof Chest)) return;
+
+                            Chest liveChest = (Chest) liveBlock.getState();
+                            Inventory inv = liveChest.getInventory();
+                            populateChest(inv, type);
+                        }, 20L);
+
+                        chestsFound++;
+                    }
+
+                    if (chestsFound >= 1) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private void populateChest(Inventory inventory, String type) {
+        SimpleLootPopulator populator = lootPopulators.get(type.toUpperCase());
+        if (populator != null) {
+            int rolls = Math.min(5 + inventory.getSize() / 9, 27);
+            populator.populate(inventory, rolls);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `CapsuleLootManager` so each time capsule can have its own loot table
- give the lilac time capsule a custom loot table and schedule loot population when capsules generate

## Testing
- `mvn -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d54c7d60833296a3fc18add687e1