### PR TITLE
feat: add monument completion system

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -35,6 +35,9 @@ import goat.thaw.system.capsule.CapsuleRegistry;
 import goat.thaw.system.capsule.CapsuleLootManager;
 import goat.thaw.subsystems.eyespy.EyeSpyManager;
 import goat.thaw.system.WolfSpawnListener;
+import goat.thaw.system.monument.MonumentListener;
+import goat.thaw.system.monument.MonumentManager;
+import goat.thaw.system.monument.MonumentRewardListener;
 
 import java.util.*;
 import goat.thaw.system.dev.BungalowLootManager;
@@ -65,6 +68,7 @@ public final class Thaw extends JavaPlugin {
     private SchemManager schematicManager;
     private BungalowLootManager lootManager;
     private CapsuleLootManager capsuleLootManager;
+    private MonumentManager monumentManager;
     private static final List<String> BUNGALOW_SCHEMATICS = Arrays.asList(
             "fire",
             "scholar",
@@ -103,6 +107,11 @@ public final class Thaw extends JavaPlugin {
         }
         lootManager = new BungalowLootManager();
         capsuleLootManager = new CapsuleLootManager();
+
+        monumentManager = new MonumentManager(this);
+        monumentManager.load();
+        getServer().getPluginManager().registerEvents(new MonumentListener(monumentManager), this);
+        getServer().getPluginManager().registerEvents(new MonumentRewardListener(this, monumentManager), this);
         
         if (getCommand("testschem") != null) {
             getCommand("testschem").setExecutor(new TestSchemCommand(schematicManager));

--- a/src/main/java/goat/thaw/system/monument/CompleteMonumentStandEvent.java
+++ b/src/main/java/goat/thaw/system/monument/CompleteMonumentStandEvent.java
@@ -1,0 +1,58 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * Fired after a monument is durably marked completed and persisted.
+ */
+public class CompleteMonumentStandEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final String monumentId;
+    private final MonumentType monumentType;
+    private final Location standLoc;
+    private final UUID playerUUID;
+    private final long timestamp;
+
+    public CompleteMonumentStandEvent(String monumentId, MonumentType monumentType,
+                                      Location standLoc, UUID playerUUID, long timestamp) {
+        this.monumentId = monumentId;
+        this.monumentType = monumentType;
+        this.standLoc = standLoc;
+        this.playerUUID = playerUUID;
+        this.timestamp = timestamp;
+    }
+
+    public String getMonumentId() {
+        return monumentId;
+    }
+
+    public MonumentType getMonumentType() {
+        return monumentType;
+    }
+
+    public Location getStandLoc() {
+        return standLoc.clone();
+    }
+
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/Monument.java
+++ b/src/main/java/goat/thaw/system/monument/Monument.java
@@ -1,0 +1,84 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Location;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Immutable representation of a monument loaded from monument.yml.
+ */
+public class Monument {
+    private final String id;
+    private final MonumentType type;
+    private final Location center;
+    private final Location base;
+    private final List<int[]> stationOffsets;
+    private final Location sign;
+
+    private boolean completed;
+    private UUID completedBy;
+    private long completedAt;
+
+    public Monument(String id, MonumentType type, Location center, Location base,
+                    List<int[]> stationOffsets, Location sign,
+                    boolean completed, UUID completedBy, long completedAt) {
+        this.id = id;
+        this.type = type;
+        this.center = center;
+        this.base = base;
+        this.stationOffsets = stationOffsets;
+        this.sign = sign;
+        this.completed = completed;
+        this.completedBy = completedBy;
+        this.completedAt = completedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public MonumentType getType() {
+        return type;
+    }
+
+    public Location getCenter() {
+        return center;
+    }
+
+    public Location getBase() {
+        return base;
+    }
+
+    public List<int[]> getStationOffsets() {
+        return stationOffsets;
+    }
+
+    public Location getSign() {
+        return sign;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public UUID getCompletedBy() {
+        return completedBy;
+    }
+
+    public long getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+    public void setCompletedBy(UUID completedBy) {
+        this.completedBy = completedBy;
+    }
+
+    public void setCompletedAt(long completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentListener.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentListener.java
@@ -1,0 +1,72 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * Handles placement detection and sign protection around monuments.
+ */
+public class MonumentListener implements Listener {
+    private final MonumentManager manager;
+
+    public MonumentListener(MonumentManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlace(BlockPlaceEvent e) {
+        Player p = e.getPlayer();
+        if (p.getGameMode() == GameMode.CREATIVE && !p.hasPermission("thaw.dev")) return;
+        Location loc = e.getBlockPlaced().getLocation();
+        Monument m = manager.getMonumentAt(loc);
+        if (m == null) return;
+        if (m.getBase().distance(loc) > 2) return;
+        if (m.isCompleted()) return;
+        if (!manager.validateStations(m)) return;
+        long ts = System.currentTimeMillis();
+        manager.markCompleted(m.getId(), p.getUniqueId(), ts);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBreak(BlockBreakEvent e) {
+        Block b = e.getBlock();
+        if (!isSign(b.getType())) return;
+        Monument m = manager.getMonumentAt(b.getLocation());
+        if (m != null && !e.getPlayer().hasPermission("thaw.dev")) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onSignChange(SignChangeEvent e) {
+        Monument m = manager.getMonumentAt(e.getBlock().getLocation());
+        if (m != null && !e.getPlayer().hasPermission("thaw.dev")) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onSignInteract(PlayerInteractEvent e) {
+        if (e.getClickedBlock() == null) return;
+        if (!isSign(e.getClickedBlock().getType())) return;
+        Monument m = manager.getMonumentAt(e.getClickedBlock().getLocation());
+        if (m != null && !e.getPlayer().hasPermission("thaw.dev")) {
+            e.setCancelled(true);
+        }
+    }
+
+    private boolean isSign(Material m) {
+        return m.name().endsWith("_SIGN") || m.name().endsWith("_WALL_SIGN");
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentManager.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentManager.java
@@ -1,0 +1,205 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Loads monument.yml and provides validation/completion utilities.
+ */
+public class MonumentManager {
+    private final JavaPlugin plugin;
+    private final Map<String, Monument> monuments = new HashMap<>();
+    private final Map<String, Lock> locks = new ConcurrentHashMap<>();
+    private File dataFile;
+
+    public MonumentManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        dataFile = new File(plugin.getDataFolder(), "monument.yml");
+        if (!dataFile.exists()) return; // generated elsewhere
+        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(dataFile);
+        ConfigurationSection root = cfg.getConfigurationSection("monuments");
+        if (root == null) return;
+        for (String id : root.getKeys(false)) {
+            ConfigurationSection s = root.getConfigurationSection(id);
+            if (s == null) continue;
+            MonumentType type;
+            try {
+                type = MonumentType.valueOf(id.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ex) {
+                continue;
+            }
+            Location center = parseLocation(s.getString("center"));
+            Location base = parseLocation(s.getString("base"));
+            List<int[]> offsets = parseOffsets(s.getList("stationOffsets"));
+            Location sign = parseLocation(s.getString("sign"));
+            boolean completed = s.getBoolean("completed", false);
+            UUID completedBy = null;
+            if (s.contains("completedBy")) {
+                try { completedBy = UUID.fromString(s.getString("completedBy")); } catch (Exception ignore) {}
+            }
+            long completedAt = s.getLong("completedAt", 0L);
+            Monument m = new Monument(id, type, center, base, offsets, sign, completed, completedBy, completedAt);
+            monuments.put(id, m);
+            locks.put(id, new ReentrantLock());
+        }
+    }
+
+    private Location parseLocation(String str) {
+        if (str == null) return null;
+        String[] parts = str.split(",");
+        if (parts.length != 4) return null;
+        World w = Bukkit.getWorld(parts[0]);
+        int x = Integer.parseInt(parts[1]);
+        int y = Integer.parseInt(parts[2]);
+        int z = Integer.parseInt(parts[3]);
+        return new Location(w, x, y, z);
+    }
+
+    private List<int[]> parseOffsets(List<?> raw) {
+        if (raw == null) return java.util.Collections.emptyList();
+        List<int[]> out = new ArrayList<>();
+        for (Object o : raw) {
+            if (o instanceof List<?> l && l.size() == 3) {
+                int x = ((Number) l.get(0)).intValue();
+                int y = ((Number) l.get(1)).intValue();
+                int z = ((Number) l.get(2)).intValue();
+                out.add(new int[]{x, y, z});
+            }
+        }
+        return out;
+    }
+
+    public Monument getMonumentAt(Location loc) {
+        if (loc == null) return null;
+        for (Monument m : monuments.values()) {
+            if (!sameWorld(loc, m.getCenter())) continue;
+            if (m.getCenter().distance(loc) <= 30) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    public Location getNearestBase(Location loc, double maxDist) {
+        Monument closest = null;
+        double best = maxDist;
+        for (Monument m : monuments.values()) {
+            if (!sameWorld(loc, m.getBase())) continue;
+            double d = m.getBase().distance(loc);
+            if (d <= best) { best = d; closest = m; }
+        }
+        return closest == null ? null : closest.getBase();
+    }
+
+    public boolean validateStations(Monument m) {
+        if (m == null) return false;
+        Location base = m.getBase();
+        World w = base.getWorld();
+        if (w == null) return false;
+        for (int[] off : m.getStationOffsets()) {
+            int x = base.getBlockX() + off[0];
+            int y = base.getBlockY() + off[1];
+            int z = base.getBlockZ() + off[2];
+            Block b = w.getBlockAt(x, y, z);
+            if (b.getType() != m.getType().getStationMaterial()) return false;
+        }
+        return true;
+    }
+
+    public boolean isCompleted(String id) {
+        Monument m = monuments.get(id);
+        return m != null && m.isCompleted();
+    }
+
+    public boolean markCompleted(String id, UUID player, long timestamp) {
+        Monument m = monuments.get(id);
+        if (m == null) return false;
+        Lock lock = locks.get(id);
+        lock.lock();
+        try {
+            if (m.isCompleted()) return false;
+            if (!validateStations(m)) return false;
+            m.setCompleted(true);
+            m.setCompletedBy(player);
+            m.setCompletedAt(timestamp);
+            if (!saveAll()) {
+                m.setCompleted(false);
+                m.setCompletedBy(null);
+                m.setCompletedAt(0L);
+                return false;
+            }
+            Bukkit.getPluginManager().callEvent(new CompleteMonumentStandEvent(id, m.getType(), m.getBase(), player, timestamp));
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean saveAll() {
+        YamlConfiguration cfg = new YamlConfiguration();
+        for (Monument m : monuments.values()) {
+            String path = "monuments." + m.getId();
+            cfg.set(path + ".center", formatLocation(m.getCenter()));
+            cfg.set(path + ".base", formatLocation(m.getBase()));
+            List<String> offs = new ArrayList<>();
+            for (int[] o : m.getStationOffsets()) {
+                offs.add("[" + o[0] + "," + o[1] + "," + o[2] + "]");
+            }
+            cfg.set(path + ".stationOffsets", offs);
+            if (m.getSign() != null) cfg.set(path + ".sign", formatLocation(m.getSign()));
+            cfg.set(path + ".completed", m.isCompleted());
+            if (m.getCompletedBy() != null) cfg.set(path + ".completedBy", m.getCompletedBy().toString());
+            if (m.getCompletedAt() != 0L) cfg.set(path + ".completedAt", m.getCompletedAt());
+        }
+        File tmp = new File(dataFile.getParentFile(), dataFile.getName() + ".tmp");
+        try {
+            cfg.save(tmp);
+            if (dataFile.exists()) {
+                String ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+                Path backup = new File(dataFile.getParentFile(), dataFile.getName() + ".bak-" + ts).toPath();
+                Files.copy(dataFile.toPath(), backup, StandardCopyOption.REPLACE_EXISTING);
+            }
+            Files.move(tmp.toPath(), dataFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            return true;
+        } catch (IOException e) {
+            Bukkit.getLogger().warning("Failed to persist monument.yml: " + e.getMessage());
+            return false;
+        } finally {
+            tmp.delete();
+        }
+    }
+
+    private String formatLocation(Location loc) {
+        return String.format(Locale.US, "%s,%d,%d,%d", loc.getWorld() == null ? "world" : loc.getWorld().getName(),
+                loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
+
+    private boolean sameWorld(Location a, Location b) {
+        return a.getWorld() != null && b.getWorld() != null && a.getWorld().getName().equals(b.getWorld().getName());
+    }
+
+    public Monument get(String id) {
+        return monuments.get(id);
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentRewardListener.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentRewardListener.java
@@ -1,0 +1,65 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+/**
+ * Handles rewards and world-side effects when a monument is completed.
+ */
+public class MonumentRewardListener implements Listener {
+    private final JavaPlugin plugin;
+    private final MonumentManager manager;
+
+    public MonumentRewardListener(JavaPlugin plugin, MonumentManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onComplete(CompleteMonumentStandEvent e) {
+        Monument m = manager.get(e.getMonumentId());
+        if (m == null) return;
+        World w = m.getBase().getWorld();
+        if (w == null) return;
+        for (int[] off : m.getStationOffsets()) {
+            int x = m.getBase().getBlockX() + off[0];
+            int y = m.getBase().getBlockY() + off[1];
+            int z = m.getBase().getBlockZ() + off[2];
+            w.getBlockAt(x, y, z).setType(m.getType().getGlassMaterial());
+        }
+        Location drop = m.getBase().clone().add(0.5, 1.0, 0.5);
+        ItemStack reward = new ItemStack(m.getType().getStationMaterial());
+        Item item = w.dropItem(drop, reward);
+        Player target = Bukkit.getPlayer(e.getPlayerUUID());
+        if (target != null) {
+            Vector vel = target.getLocation().toVector().subtract(drop.toVector()).normalize().multiply(0.4);
+            item.setVelocity(vel);
+        }
+        w.playSound(drop, Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+        spawnParticles(w, drop, m.getType());
+    }
+
+    private void spawnParticles(World w, Location loc, MonumentType type) {
+        Particle.DustOptions dust = new Particle.DustOptions(type.getColor(), 1.0f);
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (ticks >= 600) { cancel(); return; }
+                w.spawnParticle(Particle.REDSTONE, loc, 20, 0.5, 0.5, 0.5, dust);
+                ticks += 20;
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentType.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentType.java
@@ -1,0 +1,37 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Color;
+import org.bukkit.Material;
+
+/**
+ * Types of monuments and their associated station material and reward color.
+ */
+public enum MonumentType {
+    PURPLE(Material.PURPLE_TERRACOTTA, Material.PURPLE_STAINED_GLASS, Color.PURPLE),
+    BLUE(Material.BLUE_TERRACOTTA, Material.BLUE_STAINED_GLASS, Color.BLUE),
+    IRON(Material.IRON_BLOCK, Material.WHITE_STAINED_GLASS, Color.WHITE),
+    BROWN(Material.BROWN_TERRACOTTA, Material.BROWN_STAINED_GLASS, Color.fromRGB(150, 75, 0)),
+    DIAMOND(Material.DIAMOND_BLOCK, Material.LIGHT_BLUE_STAINED_GLASS, Color.AQUA);
+
+    private final Material stationMaterial;
+    private final Material glassMaterial;
+    private final Color color;
+
+    MonumentType(Material stationMaterial, Material glassMaterial, Color color) {
+        this.stationMaterial = stationMaterial;
+        this.glassMaterial = glassMaterial;
+        this.color = color;
+    }
+
+    public Material getStationMaterial() {
+        return stationMaterial;
+    }
+
+    public Material getGlassMaterial() {
+        return glassMaterial;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+}


### PR DESCRIPTION
## Summary
- manage monument metadata and completions via MonumentManager
- detect block placements and protect monument signs
- reward players and mark monuments visually when completed

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f593435c8332896f9d8edd5cde6f