### PR TITLE
fix: persist station offsets as lists

### DIFF
--- a/src/main/java/goat/thaw/system/monument/MonumentManager.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentManager.java
@@ -85,6 +85,18 @@ public class MonumentManager {
                 int y = ((Number) l.get(1)).intValue();
                 int z = ((Number) l.get(2)).intValue();
                 out.add(new int[]{x, y, z});
+            } else if (o instanceof String s) {
+                // Legacy format: "[x,y,z]"
+                String[] parts = s.replaceAll("\\[|\\]", "").split(",");
+                if (parts.length == 3) {
+                    try {
+                        int x = Integer.parseInt(parts[0].trim());
+                        int y = Integer.parseInt(parts[1].trim());
+                        int z = Integer.parseInt(parts[2].trim());
+                        out.add(new int[]{x, y, z});
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
             }
         }
         return out;
@@ -162,9 +174,9 @@ public class MonumentManager {
             String path = "monuments." + m.getId();
             cfg.set(path + ".center", formatLocation(m.getCenter()));
             cfg.set(path + ".base", formatLocation(m.getBase()));
-            List<String> offs = new ArrayList<>();
+            List<List<Integer>> offs = new ArrayList<>();
             for (int[] o : m.getStationOffsets()) {
-                offs.add("[" + o[0] + "," + o[1] + "," + o[2] + "]");
+                offs.add(Arrays.asList(o[0], o[1], o[2]));
             }
             cfg.set(path + ".stationOffsets", offs);
             if (m.getSign() != null) cfg.set(path + ".sign", formatLocation(m.getSign()));

--- a/src/test/java/goat/thaw/system/monument/MonumentManagerTest.java
+++ b/src/test/java/goat/thaw/system/monument/MonumentManagerTest.java
@@ -1,0 +1,36 @@
+package goat.thaw.system.monument;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MonumentManagerTest {
+
+    @Test
+    void parseOffsetsParsesLegacyStrings() throws Exception {
+        MonumentManager mm = new MonumentManager(null);
+        Method m = MonumentManager.class.getDeclaredMethod("parseOffsets", List.class);
+        m.setAccessible(true);
+        List<String> raw = List.of("[1,2,3]", "[4,5,6]");
+        @SuppressWarnings("unchecked")
+        List<int[]> result = (List<int[]>) m.invoke(mm, raw);
+        assertEquals(2, result.size());
+        assertArrayEquals(new int[]{1,2,3}, result.get(0));
+        assertArrayEquals(new int[]{4,5,6}, result.get(1));
+    }
+
+    @Test
+    void parseOffsetsParsesNestedLists() throws Exception {
+        MonumentManager mm = new MonumentManager(null);
+        Method m = MonumentManager.class.getDeclaredMethod("parseOffsets", List.class);
+        m.setAccessible(true);
+        List<List<Integer>> raw = List.of(List.of(7, 8, 9));
+        @SuppressWarnings("unchecked")
+        List<int[]> result = (List<int[]>) m.invoke(mm, raw);
+        assertEquals(1, result.size());
+        assertArrayEquals(new int[]{7,8,9}, result.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- persist monument station offsets as list-of-lists in `monument.yml`
- parse legacy string-based offsets for backward compatibility
- add tests covering both offset formats

## Testing
- `mvn -Djava.net.preferIPv4Stack=true test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4feb6b7b48332a1982aba82af9e16