### PR TITLE
feat: generate CTM structure once

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -35,6 +35,7 @@ import goat.thaw.system.capsule.CapsuleRegistry;
 import goat.thaw.system.capsule.CapsuleLootManager;
 import goat.thaw.subsystems.eyespy.EyeSpyManager;
 import goat.thaw.system.WolfSpawnListener;
+import goat.thaw.system.ctm.GenerateCTMEvent;
 
 import java.util.*;
 import goat.thaw.system.dev.BungalowLootManager;
@@ -65,6 +66,7 @@ public final class Thaw extends JavaPlugin {
     private SchemManager schematicManager;
     private BungalowLootManager lootManager;
     private CapsuleLootManager capsuleLootManager;
+    private boolean ctmGenerated = false;
     private static final List<String> BUNGALOW_SCHEMATICS = Arrays.asList(
             "fire",
             "scholar",
@@ -268,6 +270,22 @@ public final class Thaw extends JavaPlugin {
                         schematicManager.placeStructure(schem, loc);
                         String type = schem.toUpperCase();
                         Bukkit.getScheduler().runTaskLater(this, () -> capsuleLootManager.populateLoot(loc, type), 20L);
+                    }
+                }
+
+                List<Location> ctms;
+                synchronized (gen.ctmQueue) {
+                    ctms = new ArrayList<>(gen.ctmQueue);
+                    gen.ctmQueue.clear();
+                }
+
+                if (!ctmGenerated) {
+                    for (Location loc : ctms) {
+                        if (!isValidCapsuleLocation(loc)) continue;
+                        schematicManager.placeStructure("ctm", loc);
+                        Bukkit.getPluginManager().callEvent(new GenerateCTMEvent(loc));
+                        ctmGenerated = true;
+                        break;
                     }
                 }
             }, 200L, 200L);

--- a/src/main/java/goat/thaw/system/ctm/GenerateCTMEvent.java
+++ b/src/main/java/goat/thaw/system/ctm/GenerateCTMEvent.java
@@ -1,0 +1,31 @@
+package goat.thaw.system.ctm;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a CTM structure is generated.
+ */
+public class GenerateCTMEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Location location;
+
+    public GenerateCTMEvent(Location location) {
+        this.location = location;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/goat/thaw/system/dev/ArcticChunkGenerator.java
+++ b/src/main/java/goat/thaw/system/dev/ArcticChunkGenerator.java
@@ -82,6 +82,8 @@ public class ArcticChunkGenerator extends ChunkGenerator {
     public final List<Location> bungalowQueue = Collections.synchronizedList(new ArrayList<>());
     public final List<Location> placedBungalows = Collections.synchronizedList(new ArrayList<>());
     public final List<Location> capsuleQueue = Collections.synchronizedList(new ArrayList<>());
+    public final List<Location> ctmQueue = Collections.synchronizedList(new ArrayList<>());
+    private boolean ctmQueued = false;
     private static ArcticChunkGenerator instance;
 
     public ArcticChunkGenerator() {
@@ -1806,6 +1808,7 @@ public class ArcticChunkGenerator extends ChunkGenerator {
                             }
                             if (res != null) {
                                 queueCapsule(world, res, chunkX, chunkZ);
+                                queueCtm(world, res, chunkX, chunkZ);
                                 if (res.y <= 165) {
                                     dentTowardsAir(data, chunkBaseX, chunkBaseZ, res.x, res.y, res.z, yMin, yMax);
                                 }
@@ -1817,6 +1820,7 @@ public class ArcticChunkGenerator extends ChunkGenerator {
                                     1.9, 1.5, 6.5, false, false);
                             if (res != null) {
                                 queueCapsule(world, res, chunkX, chunkZ);
+                                queueCtm(world, res, chunkX, chunkZ);
                                 if (res.y <= 165) {
                                     dentTowardsAir(data, chunkBaseX, chunkBaseZ, res.x, res.y, res.z, yMin, yMax);
                                 }
@@ -1831,6 +1835,7 @@ public class ArcticChunkGenerator extends ChunkGenerator {
                                     1.5, 1.0, 4.0, true, true);
                             if (res != null) {
                                 queueCapsule(world, res, chunkX, chunkZ);
+                                queueCtm(world, res, chunkX, chunkZ);
                                 if (res.y <= 165) {
                                     dentTowardsAir(data, chunkBaseX, chunkBaseZ, res.x, res.y, res.z, yMin, yMax);
                                 }
@@ -1855,6 +1860,19 @@ public class ArcticChunkGenerator extends ChunkGenerator {
         synchronized (capsuleQueue) {
             capsuleQueue.add(loc);
         }
+    }
+
+    private void queueCtm(World world, StepResult res, int chunkX, int chunkZ) {
+        if (ctmQueued) return;
+        int endChunkX = Math.floorDiv((int) Math.floor(res.x), 16);
+        int endChunkZ = Math.floorDiv((int) Math.floor(res.z), 16);
+        if (endChunkX != chunkX || endChunkZ != chunkZ) return;
+
+        Location loc = new Location(world, Math.floor(res.x), res.y, Math.floor(res.z));
+        synchronized (ctmQueue) {
+            ctmQueue.add(loc);
+        }
+        ctmQueued = true;
     }
 
     private CaveType pickIntersector(Random rr) {


### PR DESCRIPTION
## Summary
- Generate CTM using the same checks as time capsules and ensure only one CTM spawns
- Queue CTM locations during world gen and fire a `GenerateCTMEvent` when placed

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c500b8d1cc8332917d8d1617f12b5d