### PR TITLE
feat: add CTM monument tracking

### DIFF
--- a/src/main/java/goat/thaw/Thaw.java
+++ b/src/main/java/goat/thaw/Thaw.java
@@ -36,6 +36,7 @@ import goat.thaw.system.capsule.CapsuleLootManager;
 import goat.thaw.subsystems.eyespy.EyeSpyManager;
 import goat.thaw.system.WolfSpawnListener;
 import goat.thaw.system.ctm.GenerateCTMEvent;
+import goat.thaw.system.monument.MonumentManager;
 
 import java.util.*;
 import goat.thaw.system.dev.BungalowLootManager;
@@ -66,6 +67,7 @@ public final class Thaw extends JavaPlugin {
     private SchemManager schematicManager;
     private BungalowLootManager lootManager;
     private CapsuleLootManager capsuleLootManager;
+    private MonumentManager monumentManager;
     private boolean ctmGenerated = false;
     private static final List<String> BUNGALOW_SCHEMATICS = Arrays.asList(
             "fire",
@@ -78,6 +80,10 @@ public final class Thaw extends JavaPlugin {
     );
     public static Thaw getInstance() {
         return instance;
+    }
+
+    public MonumentManager getMonumentManager() {
+        return monumentManager;
     }
     @Override
     public void onEnable() {
@@ -105,6 +111,8 @@ public final class Thaw extends JavaPlugin {
         }
         lootManager = new BungalowLootManager();
         capsuleLootManager = new CapsuleLootManager();
+        monumentManager = new MonumentManager(this);
+        getServer().getPluginManager().registerEvents(monumentManager, this);
         
         if (getCommand("testschem") != null) {
             getCommand("testschem").setExecutor(new TestSchemCommand(schematicManager));

--- a/src/main/java/goat/thaw/system/monument/CompleteMonumentEvent.java
+++ b/src/main/java/goat/thaw/system/monument/CompleteMonumentEvent.java
@@ -1,0 +1,57 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * Fired when a monument stand is fully completed.
+ */
+public class CompleteMonumentEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final String monumentId;
+    private final MonumentType monumentType;
+    private final Location standLocation;
+    private final UUID player;
+    private final long timestamp;
+
+    public CompleteMonumentEvent(String monumentId, MonumentType type, Location standLocation, UUID player, long timestamp) {
+        this.monumentId = monumentId;
+        this.monumentType = type;
+        this.standLocation = standLocation;
+        this.player = player;
+        this.timestamp = timestamp;
+    }
+
+    public String getMonumentId() {
+        return monumentId;
+    }
+
+    public MonumentType getMonumentType() {
+        return monumentType;
+    }
+
+    public Location getStandLocation() {
+        return standLocation;
+    }
+
+    public UUID getPlayer() {
+        return player;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentManager.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentManager.java
@@ -1,0 +1,264 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import goat.thaw.system.ctm.GenerateCTMEvent;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.ChatColor;
+import org.bukkit.Tag;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Handles monument persistence and detection.
+ */
+public class MonumentManager implements Listener {
+
+    private final Plugin plugin;
+    private final File file;
+    private FileConfiguration config;
+    private Location center;
+    private final EnumMap<MonumentType, Boolean> completion = new EnumMap<>(MonumentType.class);
+
+    public MonumentManager(Plugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "monument.yml");
+        load();
+    }
+
+    private void load() {
+        if (!file.exists()) {
+            plugin.getDataFolder().mkdirs();
+            config = new YamlConfiguration();
+            for (MonumentType type : MonumentType.values()) {
+                completion.put(type, false);
+            }
+            save();
+            return;
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+        if (config.contains("center")) {
+            String world = config.getString("center.world");
+            double x = config.getDouble("center.x");
+            double y = config.getDouble("center.y");
+            double z = config.getDouble("center.z");
+            World w = world != null ? Bukkit.getWorld(world) : null;
+            if (w != null) {
+                center = new Location(w, x, y, z);
+            }
+        }
+        for (MonumentType type : MonumentType.values()) {
+            completion.put(type, config.getBoolean("monuments." + type.name(), false));
+        }
+    }
+
+    private void save() {
+        if (config == null) config = new YamlConfiguration();
+        if (center != null) {
+            config.set("center.world", center.getWorld().getName());
+            config.set("center.x", center.getX());
+            config.set("center.y", center.getY());
+            config.set("center.z", center.getZ());
+        }
+        for (Map.Entry<MonumentType, Boolean> e : completion.entrySet()) {
+            config.set("monuments." + e.getKey().name(), e.getValue());
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isCompleted(MonumentType type) {
+        return completion.getOrDefault(type, false);
+    }
+
+    private void markCompleted(MonumentType type) {
+        completion.put(type, true);
+        save();
+    }
+
+    @EventHandler
+    public void onGenerate(GenerateCTMEvent event) {
+        center = event.getLocation();
+        for (MonumentType type : MonumentType.values()) {
+            completion.put(type, false);
+        }
+        save();
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (center == null) return;
+        if (!isNearCenter(event.getBlockPlaced().getLocation(), 30)) return;
+
+        Block placed = event.getBlockPlaced();
+        Block base = findBase(placed.getLocation());
+        if (base == null) return;
+
+        Location baseLoc = base.getLocation();
+        Location placedLoc = placed.getLocation();
+        boolean station = false;
+        for (int dy = 1; dy <= 3; dy++) {
+            if (placedLoc.getBlockX() == baseLoc.getBlockX() && placedLoc.getBlockY() == baseLoc.getBlockY() + dy && placedLoc.getBlockZ() == baseLoc.getBlockZ()) {
+                station = true;
+                break;
+            }
+        }
+        if (!station) return;
+
+        Sign sign = findSign(base.getLocation());
+        if (sign == null) return;
+
+        String line = ChatColor.stripColor(sign.getLine(1)).trim();
+        MonumentType type = MonumentType.fromId(line);
+        if (type == null) return;
+
+        if (!checkFilled(base.getLocation(), type)) return;
+
+        if (isCompleted(type)) return;
+
+        Player player = event.getPlayer();
+        markCompleted(type);
+        replaceWithGlass(base.getLocation(), type);
+        rewardPlayer(player, base.getLocation(), type);
+        playCelebration(base.getLocation(), type);
+        Bukkit.getPluginManager().callEvent(new CompleteMonumentEvent(line, type, base.getLocation(), player.getUniqueId(), System.currentTimeMillis()));
+    }
+
+    @EventHandler
+    public void onSignInteract(PlayerInteractEvent event) {
+        if (center == null) return;
+        if (!event.hasBlock()) return;
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+        if (!Tag.SIGNS.isTagged(block.getType())) return;
+        if (!isNearCenter(block.getLocation(), 30)) return;
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onSignBreak(BlockBreakEvent event) {
+        if (center == null) return;
+        Block block = event.getBlock();
+        if (!Tag.SIGNS.isTagged(block.getType())) return;
+        if (!isNearCenter(block.getLocation(), 30)) return;
+        event.setCancelled(true);
+    }
+
+    private boolean isNearCenter(Location loc, double radius) {
+        if (center == null || loc.getWorld() == null) return false;
+        if (!center.getWorld().equals(loc.getWorld())) return false;
+        return loc.distanceSquared(center) <= radius * radius;
+    }
+
+    @Nullable
+    private Block findBase(Location placed) {
+        World world = placed.getWorld();
+        if (world == null) return null;
+        Block below = world.getBlockAt(placed.getBlockX(), placed.getBlockY() - 1, placed.getBlockZ());
+        if (below.getType() == Material.BEDROCK) return below;
+        int radius = 2;
+        Block nearest = null;
+        double best = Double.MAX_VALUE;
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                for (int dz = -radius; dz <= radius; dz++) {
+                    Block b = world.getBlockAt(placed.getBlockX() + dx, placed.getBlockY() + dy, placed.getBlockZ() + dz);
+                    if (b.getType() == Material.BEDROCK) {
+                        double dist = b.getLocation().distanceSquared(placed);
+                        if (dist < best) {
+                            best = dist;
+                            nearest = b;
+                        }
+                    }
+                }
+            }
+        }
+        return nearest;
+    }
+
+    @Nullable
+    private Sign findSign(Location base) {
+        World world = base.getWorld();
+        if (world == null) return null;
+        int radius = 2;
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -radius; dy <= radius; dy++) {
+                for (int dz = -radius; dz <= radius; dz++) {
+                    Block b = world.getBlockAt(base.getBlockX() + dx, base.getBlockY() + dy, base.getBlockZ() + dz);
+                    if (Tag.SIGNS.isTagged(b.getType())) {
+                        BlockState state = b.getState();
+                        if (state instanceof Sign sign) {
+                            return sign;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean checkFilled(Location base, MonumentType type) {
+        World world = base.getWorld();
+        if (world == null) return false;
+        for (int dy = 1; dy <= 3; dy++) {
+            Block b = world.getBlockAt(base.getBlockX(), base.getBlockY() + dy, base.getBlockZ());
+            if (b.getType() != type.getRequiredMaterial()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void replaceWithGlass(Location base, MonumentType type) {
+        World world = base.getWorld();
+        if (world == null) return;
+        for (int dy = 1; dy <= 3; dy++) {
+            Block b = world.getBlockAt(base.getBlockX(), base.getBlockY() + dy, base.getBlockZ());
+            b.setType(type.getGlassMaterial(), false);
+        }
+    }
+
+    private void rewardPlayer(Player player, Location base, MonumentType type) {
+        World world = base.getWorld();
+        if (world == null) return;
+        ItemStack reward = new ItemStack(type.getRewardMaterial());
+        Location dropLoc = base.clone().add(0.5, 1.2, 0.5);
+        Item item = world.dropItem(dropLoc, reward);
+        Vector vec = player.getLocation().toVector().subtract(dropLoc.toVector()).normalize().multiply(0.5);
+        item.setVelocity(vec);
+    }
+
+    private void playCelebration(Location base, MonumentType type) {
+        World world = base.getWorld();
+        if (world == null) return;
+        world.playSound(base, Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (ticks++ > 600) { cancel(); return; }
+                world.spawnParticle(Particle.REDSTONE, base.clone().add(0.5,1,0.5), 8, 0.3, 0.5, 0.3, 0, new Particle.DustOptions(type.getColor(), 1));
+            }
+        }.runTaskTimer(plugin, 0L, 10L);
+    }
+}

--- a/src/main/java/goat/thaw/system/monument/MonumentType.java
+++ b/src/main/java/goat/thaw/system/monument/MonumentType.java
@@ -1,0 +1,77 @@
+package goat.thaw.system.monument;
+
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+
+import java.util.Locale;
+
+/**
+ * Types of CTM monuments and their required materials.
+ */
+public enum MonumentType {
+    WHITE(DyeColor.WHITE),
+    ORANGE(DyeColor.ORANGE),
+    MAGENTA(DyeColor.MAGENTA),
+    LIGHT_BLUE(DyeColor.LIGHT_BLUE),
+    YELLOW(DyeColor.YELLOW),
+    LIME(DyeColor.LIME),
+    PINK(DyeColor.PINK),
+    GRAY(DyeColor.GRAY),
+    LIGHT_GRAY(DyeColor.LIGHT_GRAY),
+    CYAN(DyeColor.CYAN),
+    PURPLE(DyeColor.PURPLE),
+    BLUE(DyeColor.BLUE),
+    BROWN(DyeColor.BROWN),
+    GREEN(DyeColor.GREEN),
+    RED(DyeColor.RED),
+    BLACK(DyeColor.BLACK),
+    IRON(Material.IRON_BLOCK, Material.GLASS, Material.IRON_INGOT, Color.fromRGB(0xD8D8D8)),
+    GOLD(Material.GOLD_BLOCK, Material.GLASS, Material.GOLD_INGOT, Color.fromRGB(0xF9FF4E)),
+    EMERALD(Material.EMERALD_BLOCK, Material.GLASS, Material.EMERALD, Color.fromRGB(0x17DD62)),
+    DIAMOND(Material.DIAMOND_BLOCK, Material.GLASS, Material.DIAMOND, Color.AQUA);
+
+    private final Material requiredMaterial;
+    private final Material glassMaterial;
+    private final Material rewardMaterial;
+    private final Color color;
+
+    MonumentType(DyeColor dye) {
+        String name = dye.name();
+        this.requiredMaterial = Material.valueOf(name + "_TERRACOTTA");
+        this.glassMaterial = Material.valueOf(name + "_STAINED_GLASS");
+        this.rewardMaterial = Material.valueOf(name + "_DYE");
+        this.color = dye.getColor();
+    }
+
+    MonumentType(Material required, Material glass, Material reward, Color color) {
+        this.requiredMaterial = required;
+        this.glassMaterial = glass;
+        this.rewardMaterial = reward;
+        this.color = color;
+    }
+
+    public Material getRequiredMaterial() {
+        return requiredMaterial;
+    }
+
+    public Material getGlassMaterial() {
+        return glassMaterial;
+    }
+
+    public Material getRewardMaterial() {
+        return rewardMaterial;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public static MonumentType fromId(String id) {
+        try {
+            return MonumentType.valueOf(id.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add monument types and completion event
- persist CTM location and monument status
- detect and reward monument completions with effects

## Testing
- `mvn -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c502662b0483329a77c96985772627